### PR TITLE
feat(notifiers): Allow multiple notifiers of the same kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Deploying this project will:
 
 - create AWS credentials for their use as GitGuardian Canary Tokens. The users associated with these credentials do not have any permissions, so they cannot perform any action.
 - create the related AWS infrastructure required to store any activities related to these credentials with [AWS CloudTrail](https://aws.amazon.com/cloudtrail/) and [AWS S3](https://aws.amazon.com/s3/).
-- create the related AWS infrastructure required to send alerts when one of the tokens is tampered to different integration such as email, native webhook and Slack. 
+- create the related AWS infrastructure required to send alerts when one of the tokens is tampered to different integration such as email, native webhook and Slack.
 
 # Project setup
 

--- a/docs/variables_reference.md
+++ b/docs/variables_reference.md
@@ -12,9 +12,9 @@ This file holds the configuration for the infrastructure and the notifiers.
 | `terraform_backend_s3_bucket` | **Optional**  | Name of the S3 bucket holding the state. Mandatory to configure with `tf_backend`       |
 | `aws_region`                  | **mandatory** | AWS region where the project will be deployed.                                          |
 | `global_prefix`               | **mandatory** | Prefix that will be used to generate unique name for resources, especially for buckets. |
-| `SES_notifier`                | Optional      | Configuration of the SES Notifier.                                                      |
-| `Slack_notifier`              | Optional      | Configuration of the Slack Notifier.                                                    |
-| `SendGrid_notifier`           | Optional      | Configuration of the SendGrid Notifier.                                                 |
+| `SES_notifiers`               | Optional      | Configuration of the SES Notifiers.                                                     |
+| `Slack_notifiers`             | Optional      | Configuration of the Slack Notifiers.                                                   |
+| `SendGrid_notifiers`          | Optional      | Configuration of the SendGrid Notifiers.                                                |
 
 See examples in [`examples/tf_vars`](/examples/tf_vars)
 

--- a/examples/tf_vars/multiple_notifiers.tfvars.example
+++ b/examples/tf_vars/multiple_notifiers.tfvars.example
@@ -10,18 +10,18 @@ aws_region  = "us-west-2"
 global_prefix = "CHANGEME"  # prefix used for all ggcanary resources
 
 
-SendGrid_notifier = {
-  enabled = true
-  parameters = {
-    SOURCE_EMAIL_ADDRESS = "canary@my_domain.org"  # email address to send emails from
-    DEST_EMAIL_ADDRESS   = "security_email@my_domain.org"  # email address receiving alerts
-    API_KEY              = "SG.XXXX"  # Account API key
-  }
-}
+SendGrid_notifiers = [{
+  source_email_address = "canary@my_domain.org"  # email address to send emails from
+  dest_email_address   = "security_email@my_domain.org"  # email address receiving alerts
+  api_key              = "SG.XXXX"  # Account API key
+}]
 
-Slack_notifier = {
-  enabled = true
-  parameters = {
-    WEBHOOK = "REDACTED"  # eg: https://hooks.slack.com/services/CHANGE/ME/FOR_REAL
+Slack_notifiers = [
+  {
+    webhook = "REDACTED"  # eg: https://hooks.slack.com/services/CHANGE/ME/FOR_REAL
+  },
+  {
+    webhook = "ANOTHER_REDACTED"
   }
-}
+]
+

--- a/examples/tf_vars/sendgrid.tfvars.example
+++ b/examples/tf_vars/sendgrid.tfvars.example
@@ -11,11 +11,8 @@ aws_region  = "us-west-2"
 global_prefix = "CHANGEME"  # prefix used for all ggcanary resources
 
 
-SendGrid_notifier = {
-  enabled = true
-  parameters = {
-    SOURCE_EMAIL_ADDRESS = "canary@my_domain.org"  # email address to send emails from
-    DEST_EMAIL_ADDRESS   = "security_email@my_domain.org"  # email address receiving alerts
-    API_KEY              = "SG.XXXX"  # Account API key
-  }
-}
+SendGrid_notifiers = [{
+  source_email_address = "canary@my_domain.org"  # email address to send emails from
+  dest_email_address   = "security_email@my_domain.org"  # email address receiving alerts
+  api_key              = "sG.XXXX"  # Account API key
+}]

--- a/examples/tf_vars/ses.tfvars.example
+++ b/examples/tf_vars/ses.tfvars.example
@@ -12,12 +12,8 @@ aws_region  = "us-west-2"
 global_prefix = "CHANGEME"  # prefix used for all ggcanary resources
 
 
-SES_notifier = {
-  enabled = true
-  parameters = {
-    SOURCE_EMAIL_ADDRESS = "canary@my_domain.org"  # email address to send emails from
-    DEST_EMAIL_ADDRESS   = "security_email@my_domain.org"  # email address receiving alerts
-    zone_id              = "000000000000"  # Value to retrieve from Route53, that corresponds to the SOURCE_EMAIL_ADDRESS domain.
-
-  }
-}
+SES_notifiers = [{
+  zone_id              = "000000000000"  # Value to retrieve from Route53, that corresponds to the SOURCE_EMAIL_ADDRESS domain.
+  source_email_address = "canary@my_domain.org"  # email address to send emails from
+  dest_email_address   = "security_email@my_domain.org"  # email address receiving alerts
+}]

--- a/examples/tf_vars/slack.tfvars.example
+++ b/examples/tf_vars/slack.tfvars.example
@@ -11,9 +11,6 @@ aws_region  = "us-west-2"
 global_prefix = "CHANGEME"  # prefix used for all ggcanary resources
 
 
-Slack_notifier = {
-  enabled = true
-  parameters = {
-    WEBHOOK = "REDACTED"  # eg: https://hooks.slack.com/services/CHANGE/ME/FOR_REAL
-  }
-}
+Slack_notifiers = [{
+  webhook = "REDACTED"  # eg: https://hooks.slack.com/services/CHANGE/ME/FOR_REAL
+}]

--- a/lambda/lambda_py/notifiers/__init__.py
+++ b/lambda/lambda_py/notifiers/__init__.py
@@ -1,11 +1,8 @@
-from typing import List, Type
-
-from .abstract_notifier import INotifier
 from .sendgrid_notifier import SendGridNotifier
 from .ses_notifier import SESNotifier
 from .slack_notifier import SlackNotifier
 
 
-NOTIFIER_CLASSES: List[Type[INotifier]] = [SESNotifier, SlackNotifier, SendGridNotifier]
+NOTIFIER_CLASSES = (SESNotifier, SlackNotifier, SendGridNotifier)
 
-__all__ = (NOTIFIER_CLASSES,)
+__all__ = NOTIFIER_CLASSES

--- a/lambda/lambda_py/notifiers/abstract_notifier.py
+++ b/lambda/lambda_py/notifiers/abstract_notifier.py
@@ -1,32 +1,12 @@
 import abc
-import os
 from typing import List
 
 from ..types import ReportEntry
 
 
 class INotifier(abc.ABC):
-    NAME = "ABSTRACT"
+    kind: str
 
     @abc.abstractmethod
     def send_notification(self, events: List[ReportEntry]):
         pass
-
-    @classmethod
-    def param(cls, param_name):
-        return cls.params()[param_name]
-
-    @classmethod
-    def params(cls):
-        prefix = cls.NAME + "_"
-        uppercased_env = {key.upper(): value for key, value in os.environ.items()}
-        return {
-            key[len(prefix) :]: value
-            for key, value in uppercased_env.items()
-            if key.startswith(prefix)
-        }
-
-    @classmethod
-    def is_enabled(cls) -> bool:
-        enabled_notifiers = os.environ.get("ENABLED_NOTIFIERS", "").upper().split(",")
-        return cls.NAME in enabled_notifiers

--- a/lambda/lambda_py/notifiers/sendgrid_notifier.py
+++ b/lambda/lambda_py/notifiers/sendgrid_notifier.py
@@ -6,7 +6,7 @@ from .webhook_notifier import IWebhookNotifier
 
 
 class SendGridNotifier(IWebhookNotifier):
-    NAME = "SENDGRID"
+    kind = "sendgrid"
     """
     Template parameters (all mandatories):
 
@@ -15,11 +15,17 @@ class SendGridNotifier(IWebhookNotifier):
     - DEST_EMAIL_ADDRESSES: ',' separated lists of recipient email addresses
     """
 
-    def __init__(self):
-        super(SendGridNotifier, self).__init__()
-        self.api_key = self.param("API_KEY")
-        self.source_email_address = self.param("SOURCE_EMAIL_ADDRESS")
-        self.dest_email_addresses = self.param("DEST_EMAIL_ADDRESSES").split(",")
+    def __init__(
+        self,
+        api_key: str,
+        source_email_address: str,
+        dest_email_addresses: List[str],
+        **kwargs,
+    ):
+        super().__init__()
+        self.api_key = api_key
+        self.source_email_address = source_email_address
+        self.dest_email_addresses = dest_email_addresses
 
     @property
     def url(self) -> str:

--- a/lambda/lambda_py/notifiers/ses_notifier.py
+++ b/lambda/lambda_py/notifiers/ses_notifier.py
@@ -8,13 +8,15 @@ from .format_utils import create_email_body, create_email_subject
 
 
 class SESNotifier(INotifier):
-    NAME = "SES"
+    kind = "ses"
 
-    def __init__(self):
-        self.dest_email_address = self.param("DEST_EMAIL_ADDRESS")
-        self.source_email_address = self.param("SOURCE_EMAIL_ADDRESS")
+    def __init__(
+        self, dest_email_address: str, source_email_address: str, **kwargs
+    ) -> None:
+        self.dest_email_address = dest_email_address
+        self.source_email_address = source_email_address
 
-    def format_report_entry(self, report_entry: ReportEntry):
+    def format_report_entry(self, report_entry: ReportEntry) -> str:
         entry_header_formatted = (
             "{report_entry.username}: {len(report_entry.records)} usage occurences.\n"
             "{report_entry.tags}"
@@ -35,7 +37,7 @@ class SESNotifier(INotifier):
             "Body": {"Text": {"Data": body, "Charset": "UTF-8"}},
         }
 
-    def send_notification(self, report_entries: List[ReportEntry]):
+    def send_notification(self, report_entries: List[ReportEntry]) -> None:
         boto3.client("ses").send_email(
             Source=self.source_email_address,
             Destination={"ToAddresses": [self.dest_email_address]},

--- a/lambda/lambda_py/notifiers/slack_notifier.py
+++ b/lambda/lambda_py/notifiers/slack_notifier.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, Dict, List
 
 from ..types import ReportEntry
 from .format_utils import format_report_entry
@@ -6,15 +6,16 @@ from .webhook_notifier import IWebhookNotifier
 
 
 class SlackNotifier(IWebhookNotifier):
-    NAME = "SLACK"
+    kind = "slack"
 
-    def __init__(self):
-        self.webhook = self.param("WEBHOOK")
+    def __init__(self, webhook, **kwargs):
+        super().__init__()
+        self.webhook = webhook
 
     @property
     def url(self):
         return self.webhook
 
-    def format_payload(self, report_entries: List[ReportEntry]):
+    def format_payload(self, report_entries: List[ReportEntry]) -> Dict[str, Any]:
         text = "\n\n".join(format_report_entry(entry) for entry in report_entries)
         return {"text": text, "type": "mrkdwn"}

--- a/lambda/lambda_py/notifiers/webhook_notifier.py
+++ b/lambda/lambda_py/notifiers/webhook_notifier.py
@@ -8,9 +8,6 @@ from .abstract_notifier import INotifier
 
 
 class IWebhookNotifier(INotifier, abc.ABC):
-    def __init__(self):
-        self.template_parameters = self.params()
-
     @abc.abstractmethod
     def format_payload(self, report_entries: List[ReportEntry]) -> Dict:
         pass

--- a/lambda/tests/data/ggcanary_lambda_parameters.json
+++ b/lambda/tests/data/ggcanary_lambda_parameters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "parameters": {
+      "dest_email_address": "security@my_domain.org",
+      "source_email_address": "canary@my_domain.org",
+      "zone_id": "XXZONEIDXX"
+    },
+    "kind": "ses"
+  },
+  {
+    "parameters": { "webhook": "https://hooks.slack.com/services/SECRET" },
+    "kind": "slack"
+  },
+  {
+    "parameters": {
+      "api_key": "secret",
+      "dest_email_addresses": "security@my_domain.org",
+      "source_email_address": "canary@my_domain.org"
+    },
+    "kind": "sendgrid"
+  }
+]

--- a/lambda/tests/test_notifiers.py
+++ b/lambda/tests/test_notifiers.py
@@ -1,41 +1,10 @@
-import os
-from unittest import mock
-
-from lambda_py.notifiers import NOTIFIER_CLASSES, SendGridNotifier, SlackNotifier
-from lambda_py.notifiers.abstract_notifier import INotifier
+from lambda_py.notifiers import NOTIFIER_CLASSES
 
 
-def test_notifiers_name_uppercase():
-    """
-    GIVEN a notifier class
-    WHEN it is one of the exported notifier, or the abstract notifier
-    THEN it's NAME attribute is uppercase
-    """
-    for notifier_class in NOTIFIER_CLASSES:
-        assert notifier_class.NAME == notifier_class.NAME.upper()
-
-    assert INotifier.NAME == INotifier.NAME.upper()
-
-
-@mock.patch.dict(
-    os.environ,
-    {
-        "SENDGRID_API_KEY": "DUMMY_API_KEY",
-        "SENDGRID_SOURCE_EMAIL_ADDRESS": "canary@ggcanary.com",
-        "SENDGRID_DEST_EMAIL_ADDRESSES": "security@ggcanary.com",
-    },
-)
-def test_sendgrid_notifier():
-    sendgrid_notifier = SendGridNotifier()
-    assert sendgrid_notifier.extra_headers == {"Authorization": "Bearer DUMMY_API_KEY"}
-
-
-@mock.patch.dict(
-    os.environ,
-    {
-        "SLACK_WEBHOOK": "https://hooks.slack.com/services/MY_WEBHOOK",
-    },
-)
-def test_slack_notifier_url():
-    slack_notifier = SlackNotifier()
-    assert slack_notifier.url == "https://hooks.slack.com/services/MY_WEBHOOK"
+def test_notifiers_distinct_names():
+    notifier_classes_by_kind = {
+        notif_class.kind: notif_class for notif_class in NOTIFIER_CLASSES
+    }
+    assert len(notifier_classes_by_kind) == len(
+        NOTIFIER_CLASSES
+    ), "multiple notifier classes have the same kind"

--- a/ses_domain_identity.tf
+++ b/ses_domain_identity.tf
@@ -1,32 +1,39 @@
 # We only want to apply this configuration when output_SES is active
 
 locals {
-  domain_name = (
-    var.SES_notifier.enabled
-    ? regex(".*@(?P<domain>.*)", var.SES_notifier.parameters.SOURCE_EMAIL_ADDRESS).domain
-    : ""
-  )
-}
-
-resource "aws_route53_record" "domain" {
-  zone_id = var.SES_notifier.parameters.zone_id
-  name    = local.domain_name
-  type    = "TXT"
-  ttl     = "60"
-  records = [
-    aws_ses_domain_identity.domain_identity[0].verification_token
-  ]
-  count = var.SES_notifier.enabled ? 1 : 0
+  zone_ids_with_domain_set = toset([
+    for notifier_config in var.SES_notifiers :
+    {
+      zone_id     = notifier_config.zone_id
+      domain_name = regex(".*@(?P<domain>.*)", notifier_config.source_email_address).domain
+    }
+  ])
+  zone_id_to_domain_map = {
+    for elem in local.zone_ids_with_domain_set :
+    elem.zone_id => elem.domain_name
+  }
 }
 
 resource "aws_ses_domain_identity" "domain_identity" {
-  domain = local.domain_name
-  count  = var.SES_notifier.enabled ? 1 : 0
+  domain   = each.value
+  for_each = local.zone_id_to_domain_map
+}
+
+
+resource "aws_route53_record" "domain" {
+  zone_id = each.key
+  name    = each.value
+  type    = "TXT"
+  ttl     = "60"
+  records = [
+    aws_ses_domain_identity.domain_identity[each.key].verification_token
+  ]
+  for_each = local.zone_id_to_domain_map
 }
 
 
 resource "aws_ses_domain_identity_verification" "domain_verification" {
-  domain     = aws_ses_domain_identity.domain_identity[0].id
+  domain     = aws_ses_domain_identity.domain_identity[each.key].id
   depends_on = [aws_route53_record.domain]
-  count      = var.SES_notifier.enabled ? 1 : 0
+  for_each   = local.zone_id_to_domain_map
 }


### PR DESCRIPTION
-  export notifiers config to a json file, uploaded along the code in the lambda
-  change variables format to allow multiple notifiers of the same type:
   - notifiers config are now arrays
   - top-level can have any variable, plus a `py_params` dict that contains values used to instantiate the python classes of the notifiers.
